### PR TITLE
Fixed issue with WebActivator naming convention

### DIFF
--- a/mvc3/nuget/Content/App_Start/NinjectMVC3.cs.pp
+++ b/mvc3/nuget/Content/App_Start/NinjectMVC3.cs.pp
@@ -44,7 +44,7 @@ namespace $rootnamespace$.App_Start
         /// Load your modules or register your services here!
         /// </summary>
         /// <param name="kernel">The kernel.</param>
-        private static void RegisterServices(IKernel kernel)
+        public static void RegisterServices(IKernel kernel)
         {
         }		
     }


### PR DESCRIPTION
Hi Remo, 

According to http://blog.davidebbo.com/2011/02/appstart-folder-convention-for-nuget.html the new naming convention suggests to put the startup code into App_Start. Currently, you are using AppStart, though. If fixed this in my fork (and I removed a superfluous ...Attribute).

Regards, 
Andre
